### PR TITLE
fix: acquire lock in tr_peerMgrPeerStats

### DIFF
--- a/libtransmission/peer-mgr.cc
+++ b/libtransmission/peer-mgr.cc
@@ -1860,21 +1860,14 @@ tr_peer_stat* tr_peerMgrPeerStats(tr_torrent const* tor, size_t* setme_count)
     auto* const ret = new tr_peer_stat[n];
 
     // TODO: re-implement as a callback solution (similar to tr_sessionSetCompletenessCallback) in case present call to run_in_session_thread is causing hangs when the peers info window is displayed.
-    auto done_promise = std::promise<void>{};
-    auto done_future = done_promise.get_future();
-    tor->session->run_in_session_thread(
-        [&peers, &ret, &done_promise]()
-        {
-            auto const now = tr_time();
-            auto const now_msec = tr_time_msec();
-            std::transform(
-                std::begin(peers),
-                std::end(peers),
-                ret,
-                [&now, &now_msec](auto const* peer) { return peer_stat_helpers::get_peer_stats(peer, now, now_msec); });
-            done_promise.set_value();
-        });
-    done_future.wait();
+    auto const lock = tor->unique_lock();
+    auto const now = tr_time();
+    auto const now_msec = tr_time_msec();
+    std::transform(
+        std::begin(peers),
+        std::end(peers),
+        ret,
+        [&now, &now_msec](auto const* peer) { return peer_stat_helpers::get_peer_stats(peer, now, now_msec); });
 
     *setme_count = n;
     return ret;


### PR DESCRIPTION
```mermaid
sequenceDiagram
    participant U as User
    participant M as Main Thread
    participant L as Session Lock<br/>std::unique_lock<std::recursive_mutex>
    participant S as Session Thread
    U->>M: Open Torrent Properties
    Note over M: Calls tr_rpc_request_exec()
    M->>L: Acquire Session Lock
    activate L
    L-->>M: Lock acquired
    Note over S: Receives block and calls<br/>tr_peerIo::can_read_wrapper()
    S-xL: Acquire Session Lock and fail
    S->>S: Wait for Session Lock to release
    Note over M: Enter tr_peerMgrPeerStats() inside RPC callback
    M->>S: Queue function to get peer stats
    Note over S: Does not progress, still waiting for Session Lock,<br/>which in turn is still being held by Main Thread
    M->>M: Stuck waiting for Session Thread
    Note over U,S: Deadlock
    M-->>U: Application hangs
    deactivate L
```